### PR TITLE
Fix collision between boss & enemy attacks

### DIFF
--- a/Assets/Scripts/BossAttack/BossProjectile.cs
+++ b/Assets/Scripts/BossAttack/BossProjectile.cs
@@ -24,12 +24,12 @@ public class BossProjectile : MonoBehaviour
     void OnTriggerEnter2D(Collider2D other)
     {
         Enemy enemy = other.transform.parent.gameObject.GetComponent<Enemy>();
-        if (enemy != null && enemy?.EnemyType == EnemyType.ENEMY || enemy?.EnemyType == EnemyType.MINION)
+        if (enemy?.EnemyType == EnemyType.ENEMY || enemy?.EnemyType == EnemyType.MINION)
         {
             enemy.applyDamageTo(this.Attack.damage);
             Destroy(this.gameObject);
         }
-        else if (other.transform.tag == "enemy")
+        else if (other.transform.tag == "enemy" && enemy?.EnemyType != EnemyType.PROJECTILE)
         {
             Destroy(this.gameObject);
         }


### PR DESCRIPTION
  * Remove redundant `enemy != null` check
  * Make sure the object the boss projectile is colliding with is not a projectile.